### PR TITLE
Dep fix

### DIFF
--- a/bin/multisig.js
+++ b/bin/multisig.js
@@ -226,10 +226,7 @@ class CLI {
 
       const {paths,inputTXs,coins,scripts,mtx} = await prepareSignMultisig({
         pmtx,
-        network,
         path: this.path,
-        wallet: this.wallet,
-        hardware: this.hardware
       });
 
       const signatures = await this.hardware.getSignature(mtx, {

--- a/lib/bsigner.js
+++ b/lib/bsigner.js
@@ -8,7 +8,8 @@ const {
   prepareSign,
   generateToken,
   prepareSignMultisig,
-  guessPath
+  guessPath,
+  getKnownPaths
 } = require('../src/app');
 
 // classes
@@ -20,3 +21,4 @@ exports.prepareSign = prepareSign;
 exports.prepareSignMultisig = prepareSignMultisig;
 exports.generateToken = generateToken;
 exports.guessPath = guessPath;
+exports.getKnownPaths = getKnownPaths;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,25 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "10.12.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
-      "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg=="
-    },
-    "@types/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "abstract-leveldown": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
       "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+      "dev": true,
       "requires": {
         "xtend": "~4.0.0"
       }
@@ -46,15 +32,6 @@
         "readable-stream": "^2.0.6"
       }
     },
-    "ascli": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ascli/-/ascli-0.3.0.tgz",
-      "integrity": "sha1-XmYjDlIZ/j6JUqTvtPIPrllqgTo=",
-      "requires": {
-        "colour": "^0.7.1",
-        "optjs": "^3.2.2"
-      }
-    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -64,34 +41,12 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base-x": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
-      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "bcfg": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.5.tgz",
       "integrity": "sha512-a3dJQnXbBAl9wrhcki+H21mTtMKUJfdTuOcnGhDGSUQqpiBD5+uYfEvBz3vDFvBsuRguxV6Jp8kZQGwrMLQHPQ==",
       "requires": {
         "bsert": "~0.0.8"
-      }
-    },
-    "bchaddrjs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/bchaddrjs/-/bchaddrjs-0.2.3.tgz",
-      "integrity": "sha512-0DVW8q3UFQFhrvt8Fowpkk+WvkYTZTSD1vGCQHrtMHZjRL6G/SoW0mgrREmgO1F/8TJ+Julri4UBWA8Gr7C5Yw==",
-      "requires": {
-        "bs58check": "^2.1.2",
-        "cashaddrjs": "^0.2.9"
       }
     },
     "bclient": {
@@ -195,11 +150,6 @@
         "bsert": "~0.0.8"
       }
     },
-    "bech32": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
-    },
     "bevent": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.4.tgz",
@@ -231,16 +181,6 @@
         "bsert": "~0.0.8"
       }
     },
-    "big-integer": {
-      "version": "1.6.42",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.42.tgz",
-      "integrity": "sha512-3UQFKcRMx+5Z+IK5vYTMYK2jzLRJkt+XqyDdacgWgtMjjuifKpKTFneJLEgeBElOE2/lXZ1LcMcb5s8pwG2U8Q=="
-    },
-    "bigi": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
-      "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
-    },
     "bindings": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -255,69 +195,13 @@
         "bsert": "~0.0.8"
       }
     },
-    "binstring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/binstring/-/binstring-0.2.1.tgz",
-      "integrity": "sha1-ihdNMB9tVO/aVQ3Zi7TLUk6s110="
-    },
     "bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "bitcoin-ops": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-    },
-    "bitcoin-script": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-script/-/bitcoin-script-0.1.1.tgz",
-      "integrity": "sha1-UsUE3dweOxMXp7ZWeoiYGz7zkpw=",
-      "requires": {
-        "big-integer": "^1.3.19",
-        "bigi": "^1.2.1",
-        "coinkey": "^0.1.0",
-        "ecdsa": "^0.6.0",
-        "js-beautify": "^1.5.4",
-        "ripemd160": "^0.2.0",
-        "secure-random": "^1.1.1",
-        "sha1": "^1.1.0",
-        "sha256": "^0.1.1"
-      },
-      "dependencies": {
-        "ripemd160": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.1.tgz",
-          "integrity": "sha1-3uGSSKPhyBX/muo551OjN/VqJD0="
-        }
-      }
-    },
-    "bitcoinjs-lib-zcash": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib-zcash/-/bitcoinjs-lib-zcash-3.6.0.tgz",
-      "integrity": "sha512-TcGM3CbyeBXtpWjYgWD1PGy2A2mYYUyfBM4bZtFDU4z1l/NMaJrUBCu1jtQfWhtRGMATrTOojLNvpE5gA8RxOA==",
-      "requires": {
-        "bech32": "^1.1.2",
-        "bigi": "^1.4.0",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.3.0",
-        "bitcoin-script": "^0.1.1",
-        "blake2b": "^2.1.2",
-        "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "ecurve": "^1.0.0",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
       }
     },
     "bl": {
@@ -327,23 +211,6 @@
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "blake2b": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
-      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
-      "requires": {
-        "blake2b-wasm": "^1.1.0",
-        "nanoassert": "^1.0.0"
-      }
-    },
-    "blake2b-wasm": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
-      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
-      "requires": {
-        "nanoassert": "^1.0.0"
       }
     },
     "bledger": {
@@ -406,6 +273,7 @@
     "bmultisig": {
       "version": "git+https://github.com/bcoin-org/bmultisig.git#ec1fd5d1f2f5f1e2f86eaf6d6d2da9be7f2075ec",
       "from": "git+https://github.com/bcoin-org/bmultisig.git",
+      "dev": true,
       "requires": {
         "bclient": "^0.1.6",
         "bcoin": "~1.0.2",
@@ -426,6 +294,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/bcoin/-/bcoin-1.0.2.tgz",
           "integrity": "sha512-eG7j7giwjWHa6et1ZSTgqELRKOFRaQYWDdpA0AbQQO1Xw5K8nqIDPuXySwO18Y9S2Ik+VkvAqL6IlmfnYzA3mw==",
+          "dev": true,
           "requires": {
             "bcfg": "~0.1.0",
             "bclient": "~0.1.1",
@@ -459,6 +328,7 @@
               "version": "0.3.7",
               "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",
               "integrity": "sha512-ZFeKszFo4abpbzLUK8sqQx87Np5ptaskhszU4Jf9JDFa1Bjuanwrv0a7z1xZJOWNG9abz8krgwvO1Z/NBtsgbg==",
+              "dev": true,
               "requires": {
                 "bindings": "~1.3.0",
                 "bn.js": "~4.11.8",
@@ -472,6 +342,7 @@
               "version": "0.2.3",
               "resolved": "https://registry.npmjs.org/bdb/-/bdb-0.2.3.tgz",
               "integrity": "sha512-GOfUit8Rq9Y5pUuD3N4zFdZ99sXfswj7QIoFyKQnqq0zmLeQ7riJcpReJZadluOWOmQovzNij75kgA/zlKRnsw==",
+              "dev": true,
               "requires": {
                 "bsert": "~0.0.3",
                 "leveldown": "4.0.1"
@@ -481,6 +352,7 @@
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.2.tgz",
               "integrity": "sha512-n7FeLSrKfsPnZstqA9PfPME1apI9u9WB35aDbsubWzLz1GjpgXewCXYyq9/m8c/IB/pFXRwqs0XwL/qq5IGJPQ==",
+              "dev": true,
               "requires": {
                 "bindings": "~1.3.0",
                 "bsert": "~0.0.3",
@@ -490,12 +362,14 @@
             "bufio": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
+              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw==",
+              "dev": true
             },
             "nan": {
               "version": "2.10.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-              "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+              "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+              "dev": true
             }
           }
         },
@@ -503,6 +377,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.0.2.tgz",
           "integrity": "sha512-JGPVqeO+uvlo+5QTEO78jL4/5UVvBcqc8UPd7ctLMQTb2FR85aocdDDKk0vtyLpXY2/orRrD51h3/Q0GwuyZAg==",
+          "dev": true,
           "requires": {
             "bindings": "~1.3.1",
             "bsert": "~0.0.8",
@@ -514,6 +389,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-0.2.0.tgz",
           "integrity": "sha512-kQ+LV1FTS3un6iiOqg9qp2kAF+fADZNMZpmv2DHMFIgRSCAjH4NHi9p9X3i34kGJlZzP7+KkySK5it/8/oWKEA==",
+          "dev": true,
           "requires": {
             "bufio": "~0.2.0",
             "mrmr": "~0.1.0"
@@ -522,7 +398,8 @@
             "bufio": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
+              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw==",
+              "dev": true
             }
           }
         },
@@ -530,6 +407,7 @@
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/bmultisig-client/-/bmultisig-client-0.0.4.tgz",
           "integrity": "sha512-tpsF+4SPbAp5qSdYlGvSc6EYEZylOdeb3ZZzgssiGPVt6Z7bOO4HBom5Zdq5z6Gik3XhiwaM6Zqo6+cgNOc/cQ==",
+          "dev": true,
           "requires": {
             "bclient": "^0.1.6",
             "bsert": "0.0.8"
@@ -556,26 +434,20 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
     },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -599,24 +471,6 @@
       "integrity": "sha512-IJuuNp3h5XJSn9QSDavROiMc9t9VbjfI4fRgdPtElG56LkB0kIdRgF+eTJpOsGqSTfBnYx/mn9nmC40Y8y9a8w==",
       "requires": {
         "bsert": "~0.0.8"
-      }
-    },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
       }
     },
     "bsert": {
@@ -693,12 +547,8 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "bufferview": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz",
-      "integrity": "sha1-ev10pF+Tf6QiodM4wIu/3HbNcl0="
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
     },
     "bufio": {
       "version": "1.0.4",
@@ -732,28 +582,6 @@
         "bsock": "~0.1.5"
       }
     },
-    "bytebuffer-old-fixed-webpack": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/bytebuffer-old-fixed-webpack/-/bytebuffer-old-fixed-webpack-3.5.6.tgz",
-      "integrity": "sha1-WtxBnGqbRpLyFyBnA+x0McdZqj8=",
-      "requires": {
-        "bufferview": "~1",
-        "long": "~2 >=2.2.3"
-      }
-    },
-    "cashaddrjs": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.2.9.tgz",
-      "integrity": "sha512-DhJF4iAH0/RM3UjHDHKRxzs09YGL9px+oTyizzydanhC7jTyM2aJ+aLKA96vZGTTWayvvr2iDF2l13lpqXiRFg==",
-      "requires": {
-        "big-integer": "^1.6.34"
-      }
-    },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
@@ -763,6 +591,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -773,86 +602,10 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "coinkey": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/coinkey/-/coinkey-0.1.0.tgz",
-      "integrity": "sha1-vfKpU9z+T9cP26MADHh/82nYKUw=",
-      "requires": {
-        "coinstring": "~0.2.0",
-        "eckey": "~0.4.0",
-        "secure-random": "~0.2.0"
-      },
-      "dependencies": {
-        "secure-random": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-0.2.1.tgz",
-          "integrity": "sha1-HC8Iy5TYwG3v9SchpgRbupb4Wpo="
-        }
-      }
-    },
-    "coinstring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-0.2.0.tgz",
-      "integrity": "sha1-+iggSXu541t8+hFvBIIZym8/NI8=",
-      "requires": {
-        "bs58": "0.3.x",
-        "crypto-hashing": "~0.3.0"
-      },
-      "dependencies": {
-        "bigi": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-          "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-        },
-        "bs58": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-0.3.0.tgz",
-          "integrity": "sha1-y0gQe/RGcn0+F7IRAtpzyokQlYg=",
-          "requires": {
-            "bigi": "0.2.0",
-            "binstring": "~0.2.0"
-          }
-        }
-      }
-    },
-    "colour": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-    },
-    "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "convert-hex": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/convert-hex/-/convert-hex-0.1.0.tgz",
-      "integrity": "sha1-CMBFaJIsJ3drii6BqV05M2LqC2U="
-    },
-    "convert-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/convert-string/-/convert-string-0.1.0.tgz",
-      "integrity": "sha1-ec5BqbsNA7z3LNxqjzxW+7xkQQo="
     },
     "core-js": {
       "version": "2.6.5",
@@ -868,6 +621,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -880,6 +634,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -887,27 +642,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
-    "crypto-hashing": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/crypto-hashing/-/crypto-hashing-0.3.1.tgz",
-      "integrity": "sha1-AZVUjbi971CqnVJlFMxUbh5i+84=",
-      "requires": {
-        "binstring": "0.2.x",
-        "ripemd160": "~0.2.0"
-      },
-      "dependencies": {
-        "ripemd160": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.1.tgz",
-          "integrity": "sha1-3uGSSKPhyBX/muo551OjN/VqJD0="
-        }
       }
     },
     "decompress-response": {
@@ -923,14 +657,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -945,96 +671,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4"
       }
     },
-    "ecdsa": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ecdsa/-/ecdsa-0.6.0.tgz",
-      "integrity": "sha1-NemIe29Bjse5g4AXAzTcJ2Omsxc=",
-      "requires": {
-        "bigi": "^1.2.1",
-        "ecurve": "^1.0.0"
-      }
-    },
-    "eckey": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/eckey/-/eckey-0.4.2.tgz",
-      "integrity": "sha1-zqU7fVKeQhaPLIWXp+jTK8njlDY=",
-      "requires": {
-        "bigi": "0.2.x",
-        "ecurve": "~0.3.0",
-        "ecurve-names": "~0.3.0"
-      },
-      "dependencies": {
-        "bigi": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-          "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-        },
-        "ecurve": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
-          "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
-          "requires": {
-            "bigi": "0.2.x"
-          }
-        }
-      }
-    },
-    "ecurve": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
-      "requires": {
-        "bigi": "^1.1.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "ecurve-names": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ecurve-names/-/ecurve-names-0.3.0.tgz",
-      "integrity": "sha1-+VJeQD9Eo197wXVX/35BCRkx1Zw=",
-      "requires": {
-        "bigi": "0.2.x",
-        "ecurve": "~0.3.0"
-      },
-      "dependencies": {
-        "bigi": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bigi/-/bigi-0.2.0.tgz",
-          "integrity": "sha1-i+4mNIuZxK4u0gSB+xI4TDJ5L3Q="
-        },
-        "ecurve": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-0.3.2.tgz",
-          "integrity": "sha1-ut7/nvlTme6i4X0bUz8BBIQkC1A=",
-          "requires": {
-            "bigi": "0.2.x"
-          }
-        }
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.2.tgz",
-      "integrity": "sha512-GWjSI19PVJAM9IZRGOS+YKI8LN+/sjkSjNyvxL5ucqP9/IqtYNXBaQ/6c/hkPNYQHyOHra2KoXZI/JVpuqwmcQ==",
-      "requires": {
-        "@types/node": "^10.11.7",
-        "@types/semver": "^5.5.0",
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.3",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      }
-    },
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -1045,14 +693,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1061,33 +701,11 @@
         "once": "^1.4.0"
       }
     },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -1102,7 +720,8 @@
     "fast-future": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo=",
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -1114,16 +733,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -1145,32 +754,6 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
-    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1180,6 +763,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -1189,6 +773,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -1198,27 +783,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1231,16 +800,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1249,61 +808,16 @@
         "number-is-nan": "^1.0.0"
       }
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "js-beautify": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.9.tgz",
-      "integrity": "sha512-MwPmLywK9RSX0SPsUJjN7i+RQY9w/yC17Lbrq9ViEefpLRgqAR2BgrMN2AbifkUuhDV8tRauLhLda/9+bE0YQA==",
-      "requires": {
-        "config-chain": "^1.1.12",
-        "editorconfig": "^0.15.2",
-        "glob": "^7.1.3",
-        "mkdirp": "~0.5.0",
-        "nopt": "~4.0.1"
-      }
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
     "leveldown": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz",
       "integrity": "sha512-ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==",
+      "dev": true,
       "requires": {
         "abstract-leveldown": "~5.0.0",
         "bindings": "~1.3.0",
@@ -1315,17 +829,20 @@
         "expand-template": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+          "dev": true
         },
         "nan": {
           "version": "2.10.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
         },
         "prebuild-install": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
           "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+          "dev": true,
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^1.0.2",
@@ -1346,34 +863,16 @@
         }
       }
     },
-    "long": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
-      "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "merkle-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -1383,20 +882,14 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
     },
     "minimist": {
       "version": "1.2.0",
@@ -1438,11 +931,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
-    "nanoassert": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-      "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-    },
     "napi-build-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
@@ -1455,15 +943,6 @@
       "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
       "requires": {
         "semver": "^5.4.1"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-hid": {
@@ -1493,15 +972,6 @@
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      }
-    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -1523,22 +993,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
-    },
-    "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1547,34 +1001,10 @@
         "wrappy": "1"
       }
     },
-    "optjs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "prebuild-install": {
       "version": "5.2.4",
@@ -1605,25 +1035,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-    },
-    "protobufjs-old-fixed-webpack": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/protobufjs-old-fixed-webpack/-/protobufjs-old-fixed-webpack-3.8.5.tgz",
-      "integrity": "sha1-WBPBr58dE2u/OfT58ubz5Dw4nQY=",
-      "requires": {
-        "ascli": "~0.3",
-        "bytebuffer-old-fixed-webpack": "3.5.6"
-      }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -1631,22 +1042,6 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "pushdata-bitcoin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-      "requires": {
-        "bitcoin-ops": "^1.3.0"
-      }
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "rc": {
@@ -1683,6 +1078,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -1693,15 +1089,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "secp256k1": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "bip66": "^1.1.3",
@@ -1713,20 +1105,10 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "secure-random": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
-    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1737,33 +1119,11 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "sha1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
-      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
-      "requires": {
-        "charenc": ">= 0.0.1",
-        "crypt": ">= 0.0.1"
-      }
-    },
-    "sha256": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sha256/-/sha256-0.1.1.tgz",
-      "integrity": "sha1-NClvkEmNo+jGsG//6Ohg26KZ+QI=",
-      "requires": {
-        "convert-hex": "~0.1.0",
-        "convert-string": "~0.1.0"
-      }
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1857,37 +1217,6 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
-    "trezor-link": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/trezor-link/-/trezor-link-1.6.0.tgz",
-      "integrity": "sha512-wJnd6pUn2WYPyoqqGpPTyixUBvwKPwtq+CZ+uQFL03ttFxHzYzCCgy2cDe8gievY1S2L2MDQNX3+GovhFOzxjg==",
-      "requires": {
-        "bigi": "^1.4.1",
-        "ecurve": "^1.0.3",
-        "json-stable-stringify": "^1.0.1",
-        "node-fetch": "^1.6.0",
-        "object.values": "^1.0.3",
-        "protobufjs-old-fixed-webpack": "3.8.5",
-        "semver-compare": "^1.0.0",
-        "whatwg-fetch": "0.11.0"
-      }
-    },
-    "trezor.js": {
-      "version": "6.19.4",
-      "resolved": "https://registry.npmjs.org/trezor.js/-/trezor.js-6.19.4.tgz",
-      "integrity": "sha512-p1WPTk6dvmmVKWCw7a1n3mSjq6Tv+s/GFatIHw9xsVhKnc4LfKR3YibS7S/QLhwaf1V/0BU4zFEpRf1BSau1NA==",
-      "requires": {
-        "bchaddrjs": "^0.2.1",
-        "bitcoinjs-lib-zcash": "^3.5.2",
-        "ecurve": "^1.0.2",
-        "node-fetch": "^1.6.0",
-        "randombytes": "^2.0.1",
-        "semver-compare": "1.0.0",
-        "trezor-link": "1.6.0",
-        "unorm": "^1.3.3",
-        "whatwg-fetch": "0.11.0"
-      }
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1896,39 +1225,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-    },
     "u2f-api": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-1.0.10.tgz",
       "integrity": "sha512-0Zh+IqM2l6xaA/IUJDT9WwoEM6nwPx6ive4flVVYEfzzgXIrKFRaenieItsEkbXIgOZEw13nO3o3oLtSDOyesA==",
       "optional": true
     },
-    "unorm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.5.0.tgz",
-      "integrity": "sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw=="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "whatwg-fetch": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.0.tgz",
-      "integrity": "sha1-RrHRjQqpmVWXHvGi9arFBq3SiBU="
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -1943,14 +1249,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "requires": {
-        "bs58check": "<3.0.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1960,11 +1258,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,15 +32,6 @@
         "readable-stream": "^2.0.6"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "bcfg": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.5.tgz",
@@ -607,11 +598,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
-    "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1068,11 +1054,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "ripemd160": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Mark Tyneway",
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "bcfg": "^0.1.5",
     "bclient": "^0.1.6",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#a2e176d4",

--- a/package.json
+++ b/package.json
@@ -28,15 +28,14 @@
     "bcrypto": "3.0.1",
     "bledger": "git+https://github.com/bcoin-org/bledger.git",
     "blgr": "^0.1.5",
-    "bmultisig": "git+https://github.com/bcoin-org/bmultisig.git",
     "bmultisig-client": "git+https://github.com/bcoin-org/bmultisig-client.git",
     "bmutex": "^0.1.5",
     "bsert": "0.0.8",
     "bstring": "^0.3.5",
-    "buffer-map": "0.0.5",
-    "trezor.js": "^6.19.4"
+    "buffer-map": "0.0.5"
   },
   "devDependencies": {
-    "bmocha": "^1.0.1"
+    "bmocha": "^1.0.1",
+    "bmultisig": "git+https://github.com/bcoin-org/bmultisig.git"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -106,7 +106,8 @@ function parsePath(path, hard) {
   for (let i = 1; i < parts.length; i++) {
     let part = parts[i];
 
-    const hardened = part[part.length - 1] === '\'';
+    const last = part[part.length - 1]
+    const hardened = last === '\'' || last === 'h';
 
     if (hardened)
       part = part.slice(0, -1);

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const EventEmitter = require('events');
-// const trezor = require('trezor.js');
 const bledger = require('bledger');
 const {LedgerBcoin,LedgerTXInput} = bledger;
 const {Device} = bledger.HID;

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -309,6 +309,19 @@ class Hardware extends EventEmitter {
   }
 
   /*
+   * get serialized extended public key
+   * wraps Hardware.getPublicKey
+   * uses this.network
+   *
+   * @param path {String|[]Integer}
+   * @returns String
+   */
+  async getXPUB(path) {
+    const xpub = await this.getPublicKey(path);
+    return xpub.xpubkey(this.network);
+  }
+
+  /*
    * get public key with a lock
    * @param path {String|[]Integer}
    * @returns bcoin.HDPublicKey

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -184,7 +184,7 @@ class Hardware extends EventEmitter {
         try {
           const device = new Device({
             device: d,
-            timeout: 5000
+            timeout: 1e6
           });
 
           await device.open();
@@ -326,7 +326,7 @@ class Hardware extends EventEmitter {
     this.logger.debug('getting public key for path %s', path);
 
     try {
-      return await this._getPublicKey(path);
+      return await this._getPublicKey(path, true);
     } catch (e) {
       this.logger.debug(e.stack);
       return false;

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -339,7 +339,7 @@ class Hardware extends EventEmitter {
     this.logger.debug('getting public key for path %s', path);
 
     try {
-      return await this._getPublicKey(path, true);
+      return await this._getPublicKey(path);
     } catch (e) {
       this.logger.debug(e.stack);
       return false;
@@ -353,10 +353,10 @@ class Hardware extends EventEmitter {
    * @param path {String|[]Integer}
    * @returns bcoin.HDPublicKey
    */
-  async _getPublicKey(path) {
+  async _getPublicKey(path, getParentFingerPrint = true) {
     switch (this.vendor) {
       case vendors.LEDGER: {
-        return await this.device.getPublicKey(path);
+        return await this.device.getPublicKey(path, getParentFingerPrint);
       }
       case vendors.TREZOR: {
         throw new Error('temporarily unsupported');

--- a/test/path.js
+++ b/test/path.js
@@ -393,4 +393,69 @@ describe('Path', function () {
     assert.equal(path.coin, 14);
     assert.equal(path.account, Path.harden(1));
   });
+
+  /*
+   * NOTE: bcoin doesn't currently use ypub and zpub
+   */
+  it('should dynamically update purpose', () => {
+    const accountIndex = Path.harden(0);
+    const xpub = testxpub(accountIndex, 'regtest');
+
+    const newPurpose = Path.harden(48);
+
+    path = Path.fromAccountPublicKey(xpub.xpubkey('regtest'));
+    path.purpose = newPurpose;
+
+    assert.equal(path.purpose, newPurpose);
+
+    const list = path.toList();
+    assert.equal(list[0], newPurpose);
+
+    const str = path.toString();
+    assert.equal(str, `m'/48'/1'/0'`);
+  });
+
+  it('should dynamically update coin type', () => {
+    const purpose = '47h';
+    const coin = '5353h';
+    const account = '0h';
+
+    path = Path.fromOptions({
+      purpose,
+      coin,
+      account
+    });
+
+    const str1 = path.toString();
+    const list1 = path.toList();
+
+    assert.equal(str1, `m'/47'/5353'/0'`);
+    assert.deepEqual(list1, [
+      Path.harden(47),
+      Path.harden(5353),
+      Path.harden(0),
+    ]);
+
+    path.coin = '0h';
+    const str2 = path.toString();
+    const list2 = path.toList();
+
+    assert.equal(str2, `m'/47'/0'/0'`);
+    assert.deepEqual(list2, [
+      Path.harden(47),
+      Path.harden(0),
+      Path.harden(0)
+    ]);
+
+    path.coin = 10;
+    const str3 = path.toString();
+    const list3 = path.toList();
+
+    assert.equal(str3, `m'/47'/10/0'`);
+    assert.deepEqual(list3, [
+      Path.harden(47),
+      10,
+      Path.harden(0)
+    ]);
+  });
 });


### PR DESCRIPTION
- Delete `trezor.js` for now since it brings in so many other dependencies
- move `bmultisig` to `devDependencies` to prevent `instanceof` issues
- Implement and test dynamic path alterations
- Implement `getKnownPaths`, which will test for known keys of cointype 44 and 48
- massively bump the timeout for ledger devices
- implement `hardware.getXPUB`, which eliminates the need to pass in the network, it will use the network the device was initialized with
- Pass true to `hardware.getPublicKey` to make sure `parentFingerPrint` is returned correctly