### PR TITLE
Add bledger signMessage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,7 @@
       "ignoreReadBeforeAssign": true
     }],
     "prefer-template": "off",
-    "quotes": ["error", "single"],
+    "quotes": ["error", "single", { "allowTemplateLiterals": true }],
     "semi": ["error", "always"],
     "spaced-comment": ["error", "always", {
       "exceptions": ["!"]

--- a/bin/multisig.js
+++ b/bin/multisig.js
@@ -226,7 +226,7 @@ class CLI {
 
       const {paths,inputTXs,coins,scripts,mtx} = await prepareSignMultisig({
         pmtx,
-        path: this.path,
+        path: this.path
       });
 
       const signatures = await this.hardware.getSignature(mtx, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
       }
     },
     "bcoin": {
-      "version": "git+https://github.com/bcoin-org/bcoin.git#a2e176d4cf8fa5f5b5a320ce31f3799db1cb4f30",
-      "from": "git+https://github.com/bcoin-org/bcoin.git#a2e176d4",
+      "version": "git+https://github.com/bcoin-org/bcoin.git#d601b6a3031ea39190e1c1221b4a621b15b784e7",
+      "from": "git+https://github.com/bcoin-org/bcoin.git#master",
       "requires": {
         "bcfg": "~0.1.5",
         "bclient": "~0.1.6",
@@ -84,15 +84,32 @@
       },
       "dependencies": {
         "bcrypto": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.0.2.tgz",
-          "integrity": "sha512-JGPVqeO+uvlo+5QTEO78jL4/5UVvBcqc8UPd7ctLMQTb2FR85aocdDDKk0vtyLpXY2/orRrD51h3/Q0GwuyZAg==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.0.4.tgz",
+          "integrity": "sha512-EQC2PJpHc3UY9UOPnSdll/7Z1gOjxWuE6Ye22yPGMOlnTtYQJ1FufTshWygzWyignFIAVh9ccyWMLo5NDaYDfg==",
           "requires": {
-            "bindings": "~1.3.1",
-            "bsert": "~0.0.8",
-            "bufio": "~1.0.4",
-            "nan": "~2.12.1"
+            "bsert": "~0.0.10",
+            "bufio": "~1.0.6",
+            "loady": "~0.0.1",
+            "nan": "^2.13.1"
+          },
+          "dependencies": {
+            "bsert": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+              "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+            },
+            "bufio": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+              "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
+            }
           }
+        },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         }
       }
     },
@@ -155,13 +172,40 @@
       "integrity": "sha512-pqeG3lJbWAlYlphNzMQA/VeUNGaq7Zopvzl8hbYXzIXLIFdPqC2h2hCbZHzRlLnnaUfipmuqwWYr3qbulbuu6Q=="
     },
     "bfilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.4.tgz",
-      "integrity": "sha512-C2x1hJLlm36UBT3iBCw9FShoazFqlZQaXha7Dp0Madb0hfzrWNtf9YclHLnNfp7UlcOyAKpojne7M4FFwEcSeA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
+      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
       "requires": {
-        "bsert": "~0.0.8",
-        "bufio": "~1.0.4",
-        "mrmr": "~0.1.5"
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "mrmr": "~0.1.6"
+      },
+      "dependencies": {
+        "bsert": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+          "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+        },
+        "bufio": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+          "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
+        },
+        "mrmr": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.8.tgz",
+          "integrity": "sha512-lNav10EJsPZvlMqlBOYQ5atIO9jrlvbJ4/7asqunXY89dHooN5c+W6AV7jtvBRw4wFDR7TpEWfmBQgRGRVwBzA==",
+          "requires": {
+            "bsert": "~0.0.10",
+            "loady": "~0.0.1",
+            "nan": "^2.13.1"
+          }
+        },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+        }
       }
     },
     "bheep": {
@@ -209,11 +253,11 @@
       "from": "git+https://github.com/bcoin-org/bledger.git",
       "requires": {
         "bcrypto": "~3.0.2",
-        "blgr": "~0.1.5",
+        "blgr": "^0.1.6",
         "bmutex": "~0.1.5",
-        "bsert": "~0.0.8",
-        "buffer-map": "0.0.5",
-        "bufio": "~1.0.4",
+        "bsert": "0.0.9",
+        "buffer-map": "0.0.6",
+        "bufio": "^1.0.5",
         "node-hid": "^0.7.3",
         "u2f-api": "^1.0.8"
       },
@@ -228,6 +272,36 @@
             "bufio": "~1.0.4",
             "nan": "~2.12.1"
           }
+        },
+        "blgr": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
+          "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
+          "requires": {
+            "bsert": "~0.0.10"
+          },
+          "dependencies": {
+            "bsert": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+              "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+            }
+          }
+        },
+        "bsert": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.9.tgz",
+          "integrity": "sha512-XrJyJMeVwobda8lfNcw6naCkYwY5KtDJ+aaEWM3eAo9Nr6Z/UxuLSOo+BRU8ccMdbEvvHya44754CWlcMTjpjw=="
+        },
+        "buffer-map": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.6.tgz",
+          "integrity": "sha512-5pspGR466fgk/yjNJaqp/Z2BBJ66H2P5ty0+T5D0wwT7SiBkOFZedceu6LAm3UPFAdX0izdVJ4jXjtr7c+18zQ=="
+        },
+        "bufio": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+          "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
         }
       }
     },
@@ -266,21 +340,40 @@
       "from": "git+https://github.com/bcoin-org/bmultisig.git",
       "dev": true,
       "requires": {
-        "bclient": "^0.1.6",
+        "bclient": "^0.1.7",
         "bcoin": "~1.0.2",
-        "bcrypto": "^3.0.2",
-        "bdb": "^1.1.5",
-        "bevent": "^0.1.4",
-        "blgr": "^0.1.5",
-        "bmultisig-client": "^0.0.4",
-        "bmutex": "^0.1.5",
-        "bsert": "^0.0.8",
-        "bstring": "^0.3.5",
-        "bufio": "^1.0.4",
-        "bval": "^0.1.5",
-        "bweb": "^0.1.7"
+        "bcrypto": "^3.1.5",
+        "bdb": "^1.1.7",
+        "bevent": "^0.1.5",
+        "blgr": "^0.1.7",
+        "bmutex": "^0.1.6",
+        "bsert": "0.0.10",
+        "bstring": "^0.3.8",
+        "bufio": "^1.0.6",
+        "bval": "^0.1.6",
+        "bweb": "^0.1.8"
       },
       "dependencies": {
+        "bclient": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/bclient/-/bclient-0.1.7.tgz",
+          "integrity": "sha512-tD1b48VGrJ10Hkv1Slew88DLcIBAYbhjGIwO7fRPp0mTcc5jZjGhFjsrHwgPsChj9HYctA8yMw/ChGfheqZGDA==",
+          "requires": {
+            "bcfg": "~0.1.6",
+            "bcurl": "~0.1.6",
+            "bsert": "~0.0.10"
+          },
+          "dependencies": {
+            "bcfg": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
+              "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
+              "requires": {
+                "bsert": "~0.0.10"
+              }
+            }
+          }
+        },
         "bcoin": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/bcoin/-/bcoin-1.0.2.tgz",
@@ -365,15 +458,62 @@
           }
         },
         "bcrypto": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.0.2.tgz",
-          "integrity": "sha512-JGPVqeO+uvlo+5QTEO78jL4/5UVvBcqc8UPd7ctLMQTb2FR85aocdDDKk0vtyLpXY2/orRrD51h3/Q0GwuyZAg==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.5.tgz",
+          "integrity": "sha512-t0RLK+AxzmZ0hFHReX4SWOUL+fSGizd3PPmls1JoCaZpKXjm1oaZEXPreYpkhTyU7pawnH+ILVieANfv65S7bg==",
           "dev": true,
           "requires": {
-            "bindings": "~1.3.1",
-            "bsert": "~0.0.8",
-            "bufio": "~1.0.4",
-            "nan": "~2.12.1"
+            "bsert": "~0.0.10",
+            "bufio": "~1.0.6",
+            "loady": "~0.0.1",
+            "nan": "^2.13.1"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.13.2",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+              "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+              "dev": true
+            }
+          }
+        },
+        "bcurl": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
+          "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
+          "requires": {
+            "brq": "~0.1.7",
+            "bsert": "~0.0.10",
+            "bsock": "~0.1.8"
+          },
+          "dependencies": {
+            "bsock": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",
+              "integrity": "sha512-+rdqLWVnbYFhUTvgDuzO3KlGYXWOVS2RhRgHrRx26wSiNgmyYJSX4hK+PwtI1hEc9cyIb28Qt/hgPgSrqPlDNw==",
+              "requires": {
+                "bsert": "~0.0.10"
+              }
+            }
+          }
+        },
+        "bdb": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.7.tgz",
+          "integrity": "sha512-jtBnWEyDDK08dBbKL9LJeO2huZyBmbjBQMMVjU9RI1liJo6YDbv86uDHoaD4gniefd9pfxqOM1w6rYuwLVCXlQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10",
+            "loady": "~0.0.1"
+          }
+        },
+        "bevent": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+          "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10"
           }
         },
         "bfilter": {
@@ -394,14 +534,98 @@
             }
           }
         },
+        "blgr": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
+          "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
         "bmultisig-client": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/bmultisig-client/-/bmultisig-client-0.0.4.tgz",
           "integrity": "sha512-tpsF+4SPbAp5qSdYlGvSc6EYEZylOdeb3ZZzgssiGPVt6Z7bOO4HBom5Zdq5z6Gik3XhiwaM6Zqo6+cgNOc/cQ==",
+          "requires": {
+            "bclient": "^0.1.6"
+          }
+        },
+        "bmutex": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+          "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
           "dev": true,
           "requires": {
-            "bclient": "^0.1.6",
-            "bsert": "0.0.8"
+            "bsert": "~0.0.10"
+          }
+        },
+        "brq": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.7.tgz",
+          "integrity": "sha512-mFoSpFJx7pI8IfuNojIul7Bto4Wcp1a7SOj8MTV4Qsd6Jg3leHJFzSlTcnKfG8BIOg46nvEFDXdLmM0v0YwEPQ==",
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bsert": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+          "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+        },
+        "bstring": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.8.tgz",
+          "integrity": "sha512-OUM7JZMEbam+LA1ZwvkcuHoc+7MzL0uVFH3M3Fyd5Xx8E34eve1WPwWGMLrpZGZ30cpoGnZps0p1zbIY5fSJaw==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10",
+            "loady": "~0.0.1",
+            "nan": "^2.13.1"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.13.2",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+              "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+              "dev": true
+            }
+          }
+        },
+        "bufio": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+          "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw==",
+          "dev": true
+        },
+        "bval": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+          "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bweb": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.8.tgz",
+          "integrity": "sha512-xGMDbVf3JnLka7VTWOiy5GMersZcAuUMtd97zs7OUA/rrt2Z8bWVAwzCVPFxVzYMreYu7M+W3NZCJSpUdd7umA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.10",
+            "bsock": "~0.1.8"
+          },
+          "dependencies": {
+            "bsock": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",
+              "integrity": "sha512-+rdqLWVnbYFhUTvgDuzO3KlGYXWOVS2RhRgHrRx26wSiNgmyYJSX4hK+PwtI1hEc9cyIb28Qt/hgPgSrqPlDNw==",
+              "dev": true,
+              "requires": {
+                "bsert": "~0.0.10"
+              }
+            }
           }
         }
       }
@@ -410,8 +634,59 @@
       "version": "git+https://github.com/bcoin-org/bmultisig-client.git#7a110e814e74e147c03685cb9737bcf953f1fb11",
       "from": "git+https://github.com/bcoin-org/bmultisig-client.git",
       "requires": {
-        "bclient": "^0.1.6",
-        "bsert": "0.0.8"
+        "bclient": "~0.1.7",
+        "bsert": "~0.0.10"
+      },
+      "dependencies": {
+        "bcfg": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
+          "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bclient": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/bclient/-/bclient-0.1.7.tgz",
+          "integrity": "sha512-tD1b48VGrJ10Hkv1Slew88DLcIBAYbhjGIwO7fRPp0mTcc5jZjGhFjsrHwgPsChj9HYctA8yMw/ChGfheqZGDA==",
+          "requires": {
+            "bcfg": "~0.1.6",
+            "bcurl": "~0.1.6",
+            "bsert": "~0.0.10"
+          }
+        },
+        "bcurl": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
+          "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
+          "requires": {
+            "brq": "~0.1.7",
+            "bsert": "~0.0.10",
+            "bsock": "~0.1.8"
+          }
+        },
+        "brq": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.7.tgz",
+          "integrity": "sha512-mFoSpFJx7pI8IfuNojIul7Bto4Wcp1a7SOj8MTV4Qsd6Jg3leHJFzSlTcnKfG8BIOg46nvEFDXdLmM0v0YwEPQ==",
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        },
+        "bsert": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+          "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+        },
+        "bsock": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",
+          "integrity": "sha512-+rdqLWVnbYFhUTvgDuzO3KlGYXWOVS2RhRgHrRx26wSiNgmyYJSX4hK+PwtI1hEc9cyIb28Qt/hgPgSrqPlDNw==",
+          "requires": {
+            "bsert": "~0.0.10"
+          }
+        }
       }
     },
     "bmutex": {
@@ -848,6 +1123,11 @@
           }
         }
       }
+    },
+    "loady": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.1.tgz",
+      "integrity": "sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bcfg": "^0.1.5",
     "bclient": "^0.1.6",
-    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#a2e176d4",
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#master",
     "bcrypto": "3.0.1",
     "bledger": "git+https://github.com/bcoin-org/bledger.git",
     "blgr": "^0.1.5",

--- a/src/app.js
+++ b/src/app.js
@@ -239,7 +239,7 @@ async function getKnownPaths(hardware, wallet) {
   const out = {
     keys: [],
     paths: {}
-  }
+  };
 
   assert(hardware, 'must pass hardware');
   assert(wallet, 'must pass wallet');

--- a/src/common.js
+++ b/src/common.js
@@ -106,7 +106,7 @@ function parsePath(path, hard) {
   for (let i = 1; i < parts.length; i++) {
     let part = parts[i];
 
-    const last = part[part.length - 1]
+    const last = part[part.length - 1];
     const hardened = last === '\'' || last === 'h';
 
     if (hardened)

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -361,6 +361,26 @@ class Hardware extends EventEmitter {
     }
   }
 
+  /**
+   * Sign arbitrary messages
+   * @param  {Buffer} message Message to sign
+   * @param  {[Number[]|String]} path Full derivation path
+   * @returns {Promise}
+   */
+
+  async signMessage(message, path) {
+    assert(this.vendor === vendors.LEDGER, 'Only Ledger supports signMessage');
+
+    switch (this.vendor) {
+      case vendors.LEDGER: {
+        this.logger.debug('Signing message at %s', path);
+        return await this.device.signMessage(path, message);
+      }
+    }
+
+    return false;
+  }
+
   /*
    * sign transaction with a lock
    * and validate options

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -368,7 +368,8 @@ class Hardware extends EventEmitter {
    * @returns {Promise}
    */
 
-  async signMessage(message, path) {
+  async signMessage(path, message) {
+    assert(Buffer.isBuffer(message), 'Message must be a buffer');
     assert(this.vendor === vendors.LEDGER, 'Only Ledger supports signMessage');
 
     switch (this.vendor) {

--- a/src/path.js
+++ b/src/path.js
@@ -147,7 +147,6 @@ class Path {
     this.list[4] = value;
   }
 
-
   /*
    * create a Path from a list of integers
    */
@@ -390,7 +389,7 @@ class Path {
     assert((index >>> 0) === index);
 
     if (hardened)
-      index = Path.harden(index)
+      index = Path.harden(index);
 
     this.list.push(index);
     this.depth += 1;

--- a/test/path.js
+++ b/test/path.js
@@ -433,7 +433,7 @@ describe('Path', function () {
     assert.deepEqual(list1, [
       Path.harden(47),
       Path.harden(5353),
-      Path.harden(0),
+      Path.harden(0)
     ]);
 
     path.coin = '0h';


### PR DESCRIPTION
This adds support for signMessage from bledger. Note that currently only ledger is supported, but additional hardware support will be added in the future.

This also upgrades bcoin to latest, which changes regtest parameters, and adds new blockstore requirement. This currently causes tests to break, but the functionality still works. Tests should work with minimal adjustment.